### PR TITLE
Constraint propagation solver and new hole types (4 PRs)

### DIFF
--- a/src/HerbCore.jl
+++ b/src/HerbCore.jl
@@ -19,6 +19,7 @@ export
     get_rulesequence,
     rulesonleft,
     get_node_at_location,
+    get_node_path,
     contains_hole,
     contains_variable_shaped_hole,
 

--- a/src/HerbCore.jl
+++ b/src/HerbCore.jl
@@ -20,6 +20,7 @@ export
     rulesonleft,
     get_node_at_location,
     get_node_path,
+    number_of_holes,
     contains_hole,
     contains_variable_shaped_hole,
 

--- a/src/HerbCore.jl
+++ b/src/HerbCore.jl
@@ -23,6 +23,7 @@ export
     number_of_holes,
     contains_hole,
     contains_variable_shaped_hole,
+    get_children,
 
     Constraint,
     Grammar

--- a/src/HerbCore.jl
+++ b/src/HerbCore.jl
@@ -20,6 +20,7 @@ export
     rulesonleft,
     get_node_at_location,
     contains_hole,
+    contains_variable_shaped_hole,
 
     Constraint,
     Grammar

--- a/src/HerbCore.jl
+++ b/src/HerbCore.jl
@@ -8,6 +8,8 @@ export
     AbstractRuleNode,
     RuleNode,
     Hole,
+    FixedShapedHole,
+    VariableShapedHole,
     HoleReference,
 
     depth,

--- a/src/rulenode.jl
+++ b/src/rulenode.jl
@@ -38,9 +38,31 @@ A [`Hole`](@ref) is a placeholder where certain rules from the grammar can still
 The `domain` of a [`Hole`](@ref) defines which rules can be applied.
 The `domain` is a bitvector, where the `i`th bit is set to true if the `i`th rule in the grammar can be applied. 
 """
-mutable struct Hole <: AbstractRuleNode
+abstract type Hole <: AbstractRuleNode end
+
+"""
+FixedShapedHole <: Hole
+
+- `domain`: A bitvector, where the `i`th bit is set to true if the `i`th rule in the grammar can be applied. All rules in the domain are required to have the same childtypes.
+- `children`: The children of this hole in the expression tree.
+"""
+mutable struct FixedShapedHole <: Hole
+	domain::BitVector
+	children::Vector{AbstractRuleNode}
+end
+
+
+"""
+FixedShapedHole <: Hole
+
+- `domain`: A bitvector, where the `i`th bit is set to true if the `i`th rule in the grammar can be applied.
+"""
+mutable struct VariableShapedHole <: Hole
 	domain::BitVector
 end
+
+
+Hole(domain::BitVector) = VariableShapedHole(domain)
 
 
 """
@@ -60,10 +82,7 @@ RuleNode(ind::Int) = RuleNode(ind, nothing, AbstractRuleNode[])
 
 Create a [`RuleNode`](@ref) for the [`Grammar`](@ref) rule with index `ind` and `children` as subtrees.
 """
-RuleNode(ind::Int, children::Vector{AbstractRuleNode}) = RuleNode(ind, nothing, children)
-RuleNode(ind::Int, children::Vector{RuleNode}) = RuleNode(ind, nothing, children)
-RuleNode(ind::Int, children::Vector{Hole}) = RuleNode(ind, nothing, children)
-
+RuleNode(ind::Int, children::Vector{<:AbstractRuleNode}) = RuleNode(ind, nothing, children)
 
 """
 	RuleNode(ind::Int, _val::Any)

--- a/src/rulenode.jl
+++ b/src/rulenode.jl
@@ -216,7 +216,7 @@ _rulenode_compare(::Hole, ::Hole) = 0
 	depth(root::RuleNode)::Int
 
 Return the depth of the [`AbstractRuleNode`](@ref) tree rooted at root.
-Holes don count towards the depth.
+Holes do count towards the depth.
 """
 function depth(root::AbstractRuleNode)::Int
 	retval = 1
@@ -365,7 +365,7 @@ rulesonleft(h::Hole, loc::Vector{Int}) = Set{Int}(findall(h.domain))
 
 
 """
-	get_node_at_location(root::RuleNode, location::Vector{Int})
+	get_node_at_location(root::AbstractRuleNode, location::Vector{Int})
 
 Retrieves a [`RuleNode`](@ref) at the given location by reference. 
 """
@@ -377,11 +377,16 @@ function get_node_at_location(root::AbstractRuleNode, location::Vector{Int})
     end
 end
 
+"""
+	get_node_at_location(root::VariableShapedHole, location::Vector{Int})
+
+Retrieves the current hole, if location is this very hole. Throws error otherwise.
+"""
 function get_node_at_location(root::VariableShapedHole, location::Vector{Int})
     if location == []
         return root
     end
-    return nothing
+	error("Node at the specified location not found.")
 end
 
 

--- a/src/rulenode.jl
+++ b/src/rulenode.jl
@@ -385,7 +385,6 @@ function get_node_at_location(root::VariableShapedHole, location::Vector{Int})
 end
 
 
-
 """
 	contains_hole(rn::RuleNode) = any(contains_hole(c) for c ∈ rn.children)
 
@@ -393,6 +392,14 @@ Checks if an [`AbstractRuleNode`](@ref) tree contains a [`Hole`](@ref).
 """
 contains_hole(rn::RuleNode) = any(contains_hole(c) for c ∈ rn.children)
 contains_hole(hole::Hole) = true
+
+"""
+	contains_variable_shaped_hole(rn::RuleNode)
+
+Checks if an [`AbstractRuleNode`](@ref) tree contains a [`VariableShapedHole`](@ref).
+"""
+contains_variable_shaped_hole(rn::AbstractRuleNode) = any(contains_variable_shaped_hole(c) for c ∈ rn.children)
+contains_variable_shaped_hole(hole::VariableShapedHole) = true
 
 get_children(rn::RuleNode)::Vector{AbstractRuleNode} = rn.children
 get_children(::VariableShapedHole)::Vector{AbstractRuleNode} = []

--- a/src/rulenode.jl
+++ b/src/rulenode.jl
@@ -1,5 +1,5 @@
 """
-	AbstractRuleNode
+    AbstractRuleNode
 
 Abstract type for representing expression trees.
 Expression trees consist of [`RuleNode`](@ref)s and [`Hole`](@ref)s.
@@ -11,7 +11,7 @@ abstract type AbstractRuleNode end
 
 
 """
-	RuleNode <: AbstractRuleNode
+    RuleNode <: AbstractRuleNode
 
 A [`RuleNode`](@ref) represents a node in an expression tree.
 Each node corresponds to a certain rule in the [`Grammar`](@ref).
@@ -22,17 +22,17 @@ A [`RuleNode`](@ref) consists of:
 - `children`: The children of this node in the expression tree
 
 !!! compat
-	Evaluate immediately functionality is not yet supported by most of Herb.jl.
+    Evaluate immediately functionality is not yet supported by most of Herb.jl.
 """
 mutable struct RuleNode <: AbstractRuleNode
-	ind::Int # index in grammar
-	_val::Any  #value of _() evals
-	children::Vector{AbstractRuleNode}
+    ind::Int # index in grammar
+    _val::Any  #value of _() evals
+    children::Vector{AbstractRuleNode}
 end
 
 
 """
-	Hole <: AbstractRuleNode
+    Hole <: AbstractRuleNode
 
 A [`Hole`](@ref) is a placeholder where certain rules from the grammar can still be applied.
 The `domain` of a [`Hole`](@ref) defines which rules can be applied.
@@ -41,14 +41,14 @@ The `domain` is a bitvector, where the `i`th bit is set to true if the `i`th rul
 abstract type Hole <: AbstractRuleNode end
 
 """
-	FixedShapedHole <: Hole
+    FixedShapedHole <: Hole
 
 - `domain`: A bitvector, where the `i`th bit is set to true if the `i`th rule in the grammar can be applied. All rules in the domain are required to have the same childtypes.
 - `children`: The children of this hole in the expression tree.
 """
 mutable struct FixedShapedHole <: Hole
-	domain::BitVector
-	children::Vector{AbstractRuleNode}
+    domain::BitVector
+    children::Vector{AbstractRuleNode}
 end
 
 
@@ -58,7 +58,7 @@ VariableShapedHole <: Hole
 - `domain`: A bitvector, where the `i`th bit is set to true if the `i`th rule in the grammar can be applied.
 """
 mutable struct VariableShapedHole <: Hole
-	domain::BitVector
+    domain::BitVector
 end
 
 
@@ -66,7 +66,7 @@ Hole(domain::BitVector) = VariableShapedHole(domain)
 
 
 """
-	HoleReference
+    HoleReference
 
 Contains a hole and the path to the hole from the root of the tree.
 """
@@ -78,34 +78,34 @@ end
 
 RuleNode(ind::Int) = RuleNode(ind, nothing, AbstractRuleNode[])
 """
-	RuleNode(ind::Int, children::Vector{AbstractRuleNode})
+    RuleNode(ind::Int, children::Vector{AbstractRuleNode})
 
 Create a [`RuleNode`](@ref) for the [`Grammar`](@ref) rule with index `ind` and `children` as subtrees.
 """
 RuleNode(ind::Int, children::Vector{<:AbstractRuleNode}) = RuleNode(ind, nothing, children)
 
 """
-	RuleNode(ind::Int, _val::Any)
+    RuleNode(ind::Int, _val::Any)
 
 Create a [`RuleNode`](@ref) for the [`Grammar`](@ref) rule with index `ind`, 
 `_val` as immediately evaluated value and no children
 
 !!! warning
-	Only use this constructor if you are absolutely certain that a rule is terminal and cannot have children.
-	Use [`RuleNode(ind::Int, grammar::Grammar)`] for rules that might have children.
-	In general, [`Hole`](@ref)s should be used as a placeholder when the children of a node are not yet known.   
+    Only use this constructor if you are absolutely certain that a rule is terminal and cannot have children.
+    Use [`RuleNode(ind::Int, grammar::Grammar)`] for rules that might have children.
+    In general, [`Hole`](@ref)s should be used as a placeholder when the children of a node are not yet known.   
 
 !!! compat
-	Evaluate immediately functionality is not yet supported by most of Herb.jl.
+    Evaluate immediately functionality is not yet supported by most of Herb.jl.
 """
 RuleNode(ind::Int, _val::Any) = RuleNode(ind, _val, AbstractRuleNode[])
     
 Base.:(==)(::RuleNode, ::Hole) = false
 Base.:(==)(::Hole, ::RuleNode) = false
 Base.:(==)(A::RuleNode, B::RuleNode) = 
-	(A.ind == B.ind) && 
-	length(A.children) == length(B.children) && #required because zip doesn't check lengths
-	all(isequal(a, b) for (a, b) ∈ zip(A.children, B.children))
+    (A.ind == B.ind) && 
+    length(A.children) == length(B.children) && #required because zip doesn't check lengths
+    all(isequal(a, b) for (a, b) ∈ zip(A.children, B.children))
 # We do not know how the holes will be expanded yet, so we cannot assume equality even if the domains are equal.
 Base.:(==)(A::Hole, B::Hole) = false
 
@@ -114,66 +114,66 @@ Base.copy(h::VariableShapedHole) = VariableShapedHole(copy(h.domain))
 Base.copy(h::FixedShapedHole) = FixedShapedHole(copy(h.domain), h.children)
 
 function Base.hash(node::RuleNode, h::UInt=zero(UInt))
-	retval = hash(node.ind, h)
-	for child in node.children
-		retval = hash(child, retval)
-	end
-	return retval
+    retval = hash(node.ind, h)
+    for child in node.children
+        retval = hash(child, retval)
+    end
+    return retval
 end
 
 function Base.hash(node::Hole, h::UInt=zero(UInt))
-	return hash(node.domain, h)
+    return hash(node.domain, h)
 end
 
 function Base.show(io::IO, node::RuleNode; separator=",", last_child::Bool=false)
-	print(io, node.ind)
-	if !isempty(node.children)
-	    print(io, "{")
-	    for (i,c) in enumerate(node.children)
-		show(io, c, separator=separator, last_child=(i == length(node.children)))
-	    end
-	    print(io, "}")
-	elseif !last_child
-	    print(io, separator)
-	end
+    print(io, node.ind)
+    if !isempty(node.children)
+        print(io, "{")
+        for (i,c) in enumerate(node.children)
+        show(io, c, separator=separator, last_child=(i == length(node.children)))
+        end
+        print(io, "}")
+    elseif !last_child
+        print(io, separator)
+    end
 end
 
 function Base.show(io::IO, node::Hole; separator=",", last_child::Bool=false)
-	print(io, "hole[$(node.domain)]")
-	if !last_child
-		print(io, separator)
-	end
+    print(io, "hole[$(node.domain)]")
+    if !last_child
+        print(io, separator)
+    end
 end
 
 function Base.show(io::IO, node::FixedShapedHole; separator=",", last_child::Bool=false)
-	print(io, "fshole[$(node.domain)]")
-	if !isempty(node.children)
-	    print(io, "{")
-	    for (i,c) in enumerate(node.children)
-		show(io, c, separator=separator, last_child=(i == length(node.children)))
-	    end
-	    print(io, "}")
-	elseif !last_child
-	    print(io, separator)
-	end
+    print(io, "fshole[$(node.domain)]")
+    if !isempty(node.children)
+        print(io, "{")
+        for (i,c) in enumerate(node.children)
+        show(io, c, separator=separator, last_child=(i == length(node.children)))
+        end
+        print(io, "}")
+    elseif !last_child
+        print(io, separator)
+    end
 end
 
 """
-	Base.length(root::RuleNode)
+    Base.length(root::RuleNode)
 
 Return the number of nodes in the tree rooted at root.
 Holes don't count.
 """
 function Base.length(root::Union{RuleNode, FixedShapedHole})
-	retval = 1
-	for c in root.children
-	    retval += length(c)
-	end
-	return retval
+    retval = 1
+    for c in root.children
+        retval += length(c)
+    end
+    return retval
 end
 
 """
-	Base.length(root::VariableShapedHole)
+    Base.length(root::VariableShapedHole)
 
 Return the number of nodes in the tree rooted at root.
 Holes do count.
@@ -181,7 +181,7 @@ Holes do count.
 Base.length(::VariableShapedHole) = 1
 
 """
-	Base.isless(rn₁::AbstractRuleNode, rn₂::AbstractRuleNode)::Bool
+    Base.isless(rn₁::AbstractRuleNode, rn₂::AbstractRuleNode)::Bool
 
 Compares two [`RuleNode`](@ref)s. Returns true if the left [`RuleNode`](@ref) is less than the right [`RuleNode`](@ref).
 Order is determined from the index of the [`RuleNode`](@ref)s. 
@@ -193,18 +193,18 @@ Base.isless(rn₁::AbstractRuleNode, rn₂::AbstractRuleNode)::Bool = _rulenode_
 
 
 function _rulenode_compare(rn₁::RuleNode, rn₂::RuleNode)::Int
-	# Helper function for Base.isless
-	if rn₁.ind == rn₂.ind
-		for (c₁, c₂) ∈ zip(rn₁.children, rn₂.children)
-			comparison = _rulenode_compare(c₁, c₂)
-			if comparison ≠ 0
-				return comparison
-			end
-		end
-		return 0
-	else
-		return rn₁.ind < rn₂.ind ? -1 : 1
-	end
+    # Helper function for Base.isless
+    if rn₁.ind == rn₂.ind
+        for (c₁, c₂) ∈ zip(rn₁.children, rn₂.children)
+            comparison = _rulenode_compare(c₁, c₂)
+            if comparison ≠ 0
+                return comparison
+            end
+        end
+        return 0
+    else
+        return rn₁.ind < rn₂.ind ? -1 : 1
+    end
 end
 
 _rulenode_compare(::Hole, ::RuleNode) = -1
@@ -213,159 +213,159 @@ _rulenode_compare(::Hole, ::Hole) = 0
 
 
 """
-	depth(root::RuleNode)::Int
+    depth(root::RuleNode)::Int
 
 Return the depth of the [`AbstractRuleNode`](@ref) tree rooted at root.
 Holes do count towards the depth.
 """
 function depth(root::AbstractRuleNode)::Int
-	retval = 1
-	for c in root.children
-	    retval = max(retval, depth(c)+1)
-	end
-	return retval
+    retval = 1
+    for c in root.children
+        retval = max(retval, depth(c)+1)
+    end
+    return retval
 end
 
 depth(::VariableShapedHole) = 1
 
 
 """
-	node_depth(root::AbstractRuleNode, node::AbstractRuleNode)::Int
+    node_depth(root::AbstractRuleNode, node::AbstractRuleNode)::Int
 
 Return the depth of `node` for an [`AbstractRuleNode`](@ref) tree rooted at `root`.
 Depth is `1` when `root == node`.
 
 !!! warning
-	`node` must be a subtree of `root` in order for this function to work.
+    `node` must be a subtree of `root` in order for this function to work.
 """
 function node_depth(root::AbstractRuleNode, node::AbstractRuleNode)::Int
-	root ≡ node && return 1
-	root isa VariableShapedHole && return 1
-	for c in root.children
-	    d = node_depth(c, node)
-	    d > 0 && (return d+1)
-	end
-	return 0
+    root ≡ node && return 1
+    root isa VariableShapedHole && return 1
+    for c in root.children
+        d = node_depth(c, node)
+        d > 0 && (return d+1)
+    end
+    return 0
 end
 
 """
-	rulesoftype(node::RuleNode, ruleset::Set{Int})
+    rulesoftype(node::RuleNode, ruleset::Set{Int})
 
 Returns every rule in the ruleset that is also used in the [`AbstractRuleNode`](@ref) tree.
 """
 function rulesoftype(node::RuleNode, ruleset::Set{Int})
-	retval = Set()
+    retval = Set()
 
-	if node.ind ∈ ruleset
-		union!(retval, [node.ind])
-	end
+    if node.ind ∈ ruleset
+        union!(retval, [node.ind])
+    end
 
-	if isempty(node.children)
-		return retval
-	else
-		for child ∈ node.children
-			union!(retval, rulesoftype(child, ruleset))
-		end
+    if isempty(node.children)
+        return retval
+    else
+        for child ∈ node.children
+            union!(retval, rulesoftype(child, ruleset))
+        end
 
-		return retval
-	end
+        return retval
+    end
 end
 
 """
-	swap_node(expr::AbstractRuleNode, new_expr::AbstractRuleNode, path::Vector{Int})
+    swap_node(expr::AbstractRuleNode, new_expr::AbstractRuleNode, path::Vector{Int})
 
 Replace a node in `expr`, specified by `path`, with `new_expr`.
 Path is a sequence of child indices, starting from the root node.
 """
 function swap_node(expr::AbstractRuleNode, new_expr::AbstractRuleNode, path::Vector{Int})
-	if length(path) == 1
-		expr.children[path[begin]] = new_expr
-	else
-		swap_node(expr.children[path[begin]], new_expr, path[2:end])
-	end
+    if length(path) == 1
+        expr.children[path[begin]] = new_expr
+    else
+        swap_node(expr.children[path[begin]], new_expr, path[2:end])
+    end
 end
 
 """
-	swap_node(expr::RuleNode, node::RuleNode, child_index::Int, new_expr::RuleNode)
+    swap_node(expr::RuleNode, node::RuleNode, child_index::Int, new_expr::RuleNode)
 
 Replace child `i` of a node, a part of larger `expr`, with `new_expr`.
 """
 function swap_node(expr::RuleNode, node::RuleNode, child_index::Int, new_expr::RuleNode)
-	if expr == node 
-		node.children[child_index] = new_expr
-	else
-		for child ∈ expr.children
-			swap_node(child, node, child_index, new_expr)
-		end
-	end
+    if expr == node 
+        node.children[child_index] = new_expr
+    else
+        for child ∈ expr.children
+            swap_node(child, node, child_index, new_expr)
+        end
+    end
 end
 
 
 """
-	get_rulesequence(node::RuleNode, path::Vector{Int})
+    get_rulesequence(node::RuleNode, path::Vector{Int})
 
 Extract the derivation sequence from a path (sequence of child indices) and an [`AbstractRuleNode`](@ref).
 If the path is deeper than the deepest node, it returns what it has.
 """
 function get_rulesequence(node::RuleNode, path::Vector{Int})
-	if node.ind == 0 # sign for empty node 
-		return Vector{Int}()
-	elseif isempty(node.children) # no childnen, nowehere to follow the path; still return the index
-		return [node.ind]
-	elseif isempty(path)
-		return [node.ind]
-	elseif isassigned(path, 2)
-		# at least two items are left in the path
-		# need to access the child with get because it can happen that the child is not yet built
-		return append!([node.ind], get_rulesequence(get(node.children, path[begin], RuleNode(0)), path[2:end]))
-	else
-		# if only one item left in the path
-		# need to access the child with get because it can happen that the child is not yet built
-		return append!([node.ind], get_rulesequence(get(node.children, path[begin], RuleNode(0)), Vector{Int}()))
-	end
+    if node.ind == 0 # sign for empty node 
+        return Vector{Int}()
+    elseif isempty(node.children) # no childnen, nowehere to follow the path; still return the index
+        return [node.ind]
+    elseif isempty(path)
+        return [node.ind]
+    elseif isassigned(path, 2)
+        # at least two items are left in the path
+        # need to access the child with get because it can happen that the child is not yet built
+        return append!([node.ind], get_rulesequence(get(node.children, path[begin], RuleNode(0)), path[2:end]))
+    else
+        # if only one item left in the path
+        # need to access the child with get because it can happen that the child is not yet built
+        return append!([node.ind], get_rulesequence(get(node.children, path[begin], RuleNode(0)), Vector{Int}()))
+    end
 end
 
 get_rulesequence(::Hole, ::Vector{Int}) = Vector{Int}()
 
 """
-	rulesonleft(expr::RuleNode, path::Vector{Int})::Set{Int}
+    rulesonleft(expr::RuleNode, path::Vector{Int})::Set{Int}
 
 Finds all rules that are used in the left subtree defined by the path.
 """
 function rulesonleft(expr::RuleNode, path::Vector{Int})
-	if isempty(expr.children)
-		# if the encoutered node is terminal or non-expanded non-terminal, return node id
-		Set{Int}(expr.ind)
-	elseif isempty(path)
-		# if path is empty, collect the entire subtree
-		ruleset = Set{Int}(expr.ind)
-		for ch in expr.children
-			union!(ruleset, rulesonleft(ch, Vector{Int}()))
-		end
-		return ruleset 
-	elseif length(path) == 1
-		# if there is only one element left in the path, collect all children except the one indicated in the path
-		ruleset = Set{Int}(expr.ind)
-		for i in 1:path[begin]-1
-			union!(ruleset, rulesonleft(expr.children[i], Vector{Int}()))
-		end
-		return ruleset 
-	else
-		# collect all subtrees up to the child indexed in the path
-		ruleset = Set{Int}(expr.ind)
-		for i in 1:path[begin]-1
-			union!(ruleset, rulesonleft(expr.children[i], Vector{Int}()))
-		end
-		union!(ruleset, rulesonleft(expr.children[path[begin]], path[2:end]))
-		return ruleset 
-	end
+    if isempty(expr.children)
+        # if the encoutered node is terminal or non-expanded non-terminal, return node id
+        Set{Int}(expr.ind)
+    elseif isempty(path)
+        # if path is empty, collect the entire subtree
+        ruleset = Set{Int}(expr.ind)
+        for ch in expr.children
+            union!(ruleset, rulesonleft(ch, Vector{Int}()))
+        end
+        return ruleset 
+    elseif length(path) == 1
+        # if there is only one element left in the path, collect all children except the one indicated in the path
+        ruleset = Set{Int}(expr.ind)
+        for i in 1:path[begin]-1
+            union!(ruleset, rulesonleft(expr.children[i], Vector{Int}()))
+        end
+        return ruleset 
+    else
+        # collect all subtrees up to the child indexed in the path
+        ruleset = Set{Int}(expr.ind)
+        for i in 1:path[begin]-1
+            union!(ruleset, rulesonleft(expr.children[i], Vector{Int}()))
+        end
+        union!(ruleset, rulesonleft(expr.children[path[begin]], path[2:end]))
+        return ruleset 
+    end
 end
 
 rulesonleft(h::Hole, loc::Vector{Int}) = Set{Int}(findall(h.domain))
 
 
 """
-	get_node_at_location(root::AbstractRuleNode, location::Vector{Int})
+    get_node_at_location(root::AbstractRuleNode, location::Vector{Int})
 
 Retrieves a [`RuleNode`](@ref) at the given location by reference. 
 """
@@ -378,7 +378,7 @@ function get_node_at_location(root::AbstractRuleNode, location::Vector{Int})
 end
 
 """
-	get_node_at_location(root::VariableShapedHole, location::Vector{Int})
+    get_node_at_location(root::VariableShapedHole, location::Vector{Int})
 
 Retrieves the current hole, if location is this very hole. Throws error otherwise.
 """
@@ -386,26 +386,26 @@ function get_node_at_location(root::VariableShapedHole, location::Vector{Int})
     if location == []
         return root
     end
-	error("Node at the specified location not found.")
+    error("Node at the specified location not found.")
 end
 
 
 """
-	get_node_path(root::AbstractRuleNode, node::AbstractRuleNode)
+    get_node_path(root::AbstractRuleNode, node::AbstractRuleNode)
 
 Returns the path from the `root` to the `targetnode`. Returns nothing if no path exists.
 """
 function get_node_path(root::AbstractRuleNode, targetnode::AbstractRuleNode)::Union{Vector{Int}, Nothing}
-	if root === targetnode
-		return Vector{Int}()
-	end
-	for (i, child) ∈ enumerate(get_children(root))
-		path = get_node_path(child, targetnode)
-		if !isnothing(path)
-			return prepend!(path, i)
-		end
-	end
-	return nothing
+    if root === targetnode
+        return Vector{Int}()
+    end
+    for (i, child) ∈ enumerate(get_children(root))
+        path = get_node_path(child, targetnode)
+        if !isnothing(path)
+            return prepend!(path, i)
+        end
+    end
+    return nothing
 end
 
 
@@ -420,7 +420,7 @@ number_of_holes(rn::VariableShapedHole) = 1
 
 
 """
-	contains_hole(rn::RuleNode) = any(contains_hole(c) for c ∈ rn.children)
+    contains_hole(rn::RuleNode) = any(contains_hole(c) for c ∈ rn.children)
 
 Checks if an [`AbstractRuleNode`](@ref) tree contains a [`Hole`](@ref).
 """
@@ -428,7 +428,7 @@ contains_hole(rn::RuleNode) = any(contains_hole(c) for c ∈ rn.children)
 contains_hole(hole::Hole) = true
 
 """
-	contains_variable_shaped_hole(rn::RuleNode)
+    contains_variable_shaped_hole(rn::RuleNode)
 
 Checks if an [`AbstractRuleNode`](@ref) tree contains a [`VariableShapedHole`](@ref).
 """

--- a/src/rulenode.jl
+++ b/src/rulenode.jl
@@ -130,7 +130,7 @@ function Base.show(io::IO, node::RuleNode; separator=",", last_child::Bool=false
     if !isempty(node.children)
         print(io, "{")
         for (i,c) in enumerate(node.children)
-        show(io, c, separator=separator, last_child=(i == length(node.children)))
+            show(io, c, separator=separator, last_child=(i == length(node.children)))
         end
         print(io, "}")
     elseif !last_child

--- a/src/rulenode.jl
+++ b/src/rulenode.jl
@@ -405,6 +405,16 @@ end
 
 
 """
+    number_of_holes(rn::AbstractRuleNode)::Int
+
+Recursively counts the number of holes in an [`AbstractRuleNode`](@ref)
+"""
+number_of_holes(rn::RuleNode) = reduce(+, [number_of_holes(c) for c ∈ rn.children], init=0)
+number_of_holes(rn::FixedShapedHole) = 1 + reduce(+, [number_of_holes(c) for c ∈ rn.children], init=0)
+number_of_holes(rn::VariableShapedHole) = 1
+
+
+"""
 	contains_hole(rn::RuleNode) = any(contains_hole(c) for c ∈ rn.children)
 
 Checks if an [`AbstractRuleNode`](@ref) tree contains a [`Hole`](@ref).

--- a/src/rulenode.jl
+++ b/src/rulenode.jl
@@ -41,7 +41,7 @@ The `domain` is a bitvector, where the `i`th bit is set to true if the `i`th rul
 abstract type Hole <: AbstractRuleNode end
 
 """
-FixedShapedHole <: Hole
+	FixedShapedHole <: Hole
 
 - `domain`: A bitvector, where the `i`th bit is set to true if the `i`th rule in the grammar can be applied. All rules in the domain are required to have the same childtypes.
 - `children`: The children of this hole in the expression tree.
@@ -53,7 +53,7 @@ end
 
 
 """
-FixedShapedHole <: Hole
+VariableShapedHole <: Hole
 
 - `domain`: A bitvector, where the `i`th bit is set to true if the `i`th rule in the grammar can be applied.
 """
@@ -142,6 +142,19 @@ function Base.show(io::IO, node::Hole; separator=",", last_child::Bool=false)
 	print(io, "hole[$(node.domain)]")
 	if !last_child
 		print(io, separator)
+	end
+end
+
+function Base.show(io::IO, node::FixedShapedHole; separator=",", last_child::Bool=false)
+	print(io, "fshole[$(node.domain)]")
+	if !isempty(node.children)
+	    print(io, "{")
+	    for (i,c) in enumerate(node.children)
+		show(io, c, separator=separator, last_child=(i == length(node.children)))
+	    end
+	    print(io, "}")
+	elseif !last_child
+	    print(io, separator)
 	end
 end
 
@@ -356,7 +369,7 @@ rulesonleft(h::Hole, loc::Vector{Int}) = Set{Int}(findall(h.domain))
 
 Retrieves a [`RuleNode`](@ref) at the given location by reference. 
 """
-function get_node_at_location(root::RuleNode, location::Vector{Int})
+function get_node_at_location(root::AbstractRuleNode, location::Vector{Int})
     if location == []
         return root
     else
@@ -364,7 +377,7 @@ function get_node_at_location(root::RuleNode, location::Vector{Int})
     end
 end
 
-function get_node_at_location(root::Hole, location::Vector{Int})
+function get_node_at_location(root::VariableShapedHole, location::Vector{Int})
     if location == []
         return root
     end

--- a/src/rulenode.jl
+++ b/src/rulenode.jl
@@ -173,12 +173,12 @@ function Base.length(root::Union{RuleNode, FixedShapedHole})
 end
 
 """
-	Base.length(root::RuleNode)
+	Base.length(root::VariableShapedHole)
 
 Return the number of nodes in the tree rooted at root.
-Holes don't count.
+Holes do count.
 """
-Base.length(::VariableShapedHole) = 0
+Base.length(::VariableShapedHole) = 1
 
 """
 	Base.isless(rn₁::AbstractRuleNode, rn₂::AbstractRuleNode)::Bool
@@ -216,9 +216,9 @@ _rulenode_compare(::Hole, ::Hole) = 0
 	depth(root::RuleNode)::Int
 
 Return the depth of the [`AbstractRuleNode`](@ref) tree rooted at root.
-Holes don't count towards the depth.
+Holes don count towards the depth.
 """
-function depth(root::RuleNode)::Int
+function depth(root::AbstractRuleNode)::Int
 	retval = 1
 	for c in root.children
 	    retval = max(retval, depth(c)+1)
@@ -226,7 +226,7 @@ function depth(root::RuleNode)::Int
 	return retval
 end
 
-depth(::Hole) = 0
+depth(::VariableShapedHole) = 1
 
 
 """
@@ -240,7 +240,7 @@ Depth is `1` when `root == node`.
 """
 function node_depth(root::AbstractRuleNode, node::AbstractRuleNode)::Int
 	root ≡ node && return 1
-	root isa Hole && return 0
+	root isa VariableShapedHole && return 1
 	for c in root.children
 	    d = node_depth(c, node)
 	    d > 0 && (return d+1)

--- a/src/rulenode.jl
+++ b/src/rulenode.jl
@@ -110,7 +110,8 @@ Base.:(==)(A::RuleNode, B::RuleNode) =
 Base.:(==)(A::Hole, B::Hole) = false
 
 Base.copy(r::RuleNode) = RuleNode(r.ind, r._val, r.children)
-Base.copy(h::Hole) = Hole(copy(h.domain))
+Base.copy(h::VariableShapedHole) = VariableShapedHole(copy(h.domain))
+Base.copy(h::FixedShapedHole) = FixedShapedHole(copy(h.domain), h.children)
 
 function Base.hash(node::RuleNode, h::UInt=zero(UInt))
 	retval = hash(node.ind, h)
@@ -150,7 +151,7 @@ end
 Return the number of nodes in the tree rooted at root.
 Holes don't count.
 """
-function Base.length(root::RuleNode)
+function Base.length(root::Union{RuleNode, FixedShapedHole})
 	retval = 1
 	for c in root.children
 	    retval += length(c)
@@ -164,7 +165,7 @@ end
 Return the number of nodes in the tree rooted at root.
 Holes don't count.
 """
-Base.length(::Hole) = 0
+Base.length(::VariableShapedHole) = 0
 
 """
 	Base.isless(rn₁::AbstractRuleNode, rn₂::AbstractRuleNode)::Bool
@@ -379,3 +380,7 @@ Checks if an [`AbstractRuleNode`](@ref) tree contains a [`Hole`](@ref).
 """
 contains_hole(rn::RuleNode) = any(contains_hole(c) for c ∈ rn.children)
 contains_hole(hole::Hole) = true
+
+get_children(rn::RuleNode)::Vector{AbstractRuleNode} = rn.children
+get_children(::VariableShapedHole)::Vector{AbstractRuleNode} = []
+get_children(h::FixedShapedHole)::Vector{AbstractRuleNode} = h.children

--- a/src/rulenode.jl
+++ b/src/rulenode.jl
@@ -386,6 +386,25 @@ end
 
 
 """
+	get_node_path(root::AbstractRuleNode, node::AbstractRuleNode)
+
+Returns the path from the `root` to the `targetnode`. Returns nothing if no path exists.
+"""
+function get_node_path(root::AbstractRuleNode, targetnode::AbstractRuleNode)::Union{Vector{Int}, Nothing}
+	if root === targetnode
+		return Vector{Int}()
+	end
+	for (i, child) ∈ enumerate(get_children(root))
+		path = get_node_path(child, targetnode)
+		if !isnothing(path)
+			return prepend!(path, i)
+		end
+	end
+	return nothing
+end
+
+
+"""
 	contains_hole(rn::RuleNode) = any(contains_hole(c) for c ∈ rn.children)
 
 Checks if an [`AbstractRuleNode`](@ref) tree contains a [`Hole`](@ref).

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -94,5 +94,12 @@ using Test
             # putting out of bounds indices returns the root
             @test get_rulesequence(rulenode, [100,4,1000]) == [1]
         end
+
+        @testset "get_node_at_location" begin
+            rulenode = FixedShapedHole(BitVector((1, 1, 0, 0)), [RuleNode(3), RuleNode(4)])
+            @test get_node_at_location(rulenode, Vector{Int64}()) isa FixedShapedHole
+            @test get_node_at_location(rulenode, [1]).ind == 3
+            @test get_node_at_location(rulenode, [2]).ind == 4
+        end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -101,5 +101,23 @@ using Test
             @test get_node_at_location(rulenode, [1]).ind == 3
             @test get_node_at_location(rulenode, [2]).ind == 4
         end
+
+        @testset "get_node_path" begin
+            n1 = RuleNode(1)
+            n2 = RuleNode(2)
+            n3 = FixedShapedHole(BitVector((1, 1, 1)), [RuleNode(1), n2])
+            n4 = RuleNode(1)
+            root = RuleNode(4, [
+                RuleNode(4, [
+                    n1,
+                    RuleNode(1)
+                ]),
+                n3
+            ])
+            @test get_node_path(root, n1) == [1, 1]
+            @test get_node_path(root, n2) == [2, 2]
+            @test get_node_path(root, n3) == [2]
+            @test isnothing(get_node_path(root, n4))
+        end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -135,5 +135,18 @@ using Test
             @test depth(RuleNode(1,[RuleNode(2, [Hole(domain), RuleNode(4)])])) == 3
             @test depth(FixedShapedHole(domain,[RuleNode(2, [RuleNode(4), RuleNode(4)])])) == 3
         end
+
+        @testset "number_of_holes" begin
+            domain=BitVector((1, 1))
+            @test number_of_holes(RuleNode(1)) == 0
+            @test number_of_holes(VariableShapedHole(domain)) == 1
+            @test number_of_holes(FixedShapedHole(domain, [RuleNode(1), RuleNode(1)])) == 1
+            @test number_of_holes(FixedShapedHole(domain, [VariableShapedHole(domain), RuleNode(1)])) == 2
+            @test number_of_holes(RuleNode(2, [VariableShapedHole(domain), RuleNode(1)])) == 1
+            @test number_of_holes(FixedShapedHole(domain, [
+                VariableShapedHole(domain),
+                FixedShapedHole(domain, [VariableShapedHole(domain), RuleNode(1)])
+            ])) == 4
+        end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -119,5 +119,21 @@ using Test
             @test get_node_path(root, n3) == [2]
             @test isnothing(get_node_path(root, n4))
         end
+
+        @testset "Length tests with holes" begin
+            domain=BitVector((1, 1))
+            @test length(FixedShapedHole(domain, [])) == 1
+            @test length(FixedShapedHole(domain, [RuleNode(2)])) == 2
+            @test length(RuleNode(1,[RuleNode(2, [Hole(domain), RuleNode(4)])])) == 4
+            @test length(FixedShapedHole(domain,[RuleNode(2, [RuleNode(4), RuleNode(4)])])) == 4
+        end
+
+        @testset "Depth tests with holes" begin 
+            domain=BitVector((1, 1))
+            @test depth(FixedShapedHole(domain, [])) == 1
+            @test depth(FixedShapedHole(domain, [RuleNode(2)])) == 2
+            @test depth(RuleNode(1,[RuleNode(2, [Hole(domain), RuleNode(4)])])) == 3
+            @test depth(FixedShapedHole(domain,[RuleNode(2, [RuleNode(4), RuleNode(4)])])) == 3
+        end
     end
 end


### PR DESCRIPTION
Large PR involving 4 repositories:
- `HerbSearch` @solver
- `HerbConstraints` @solver
- `HerbCore` @holes-types
- `HerbGrammar` @holes-types (small changes)

On these respective branches, I am worked on two new major components:
1. A constraint propagation solver
2. New hole types

1. I am replacing `propagate_constraints` with a new constraint `Solver` struct. The goal is to increase the inference of constraint propagators while reducing the number of propagations needed. Currently constraint solving is integrated in the top down iterator, but the new solver should also be compatible with any type of program iterator. This means that all program iterators should be rewritten to be compatible with the constraint solver. The idea is that iterators must manipulate program trees through the solver’s API so the propagation of the constraints can happen under the hood. For example:

```julia
"""
    substitute!(solver::Solver, path::Vector{Int}, new_node::AbstractRuleNode)

Substitute the node at the `path`, with a `new_node`
"""
function substitute!(solver::Solver, path::Vector{Int}, new_node::AbstractRuleNode)
    #...
end
```

```julia
"""
    fill_hole!(solver::Solver, path::Vector{Int}, rule_index::Int)

Fill in the hole located at the `path` with rule `rule_index`.
It is assumed the path points to a hole, otherwise an exception will be thrown.
It is assumed rule_index ∈ hole.domain, otherwise an exception will be thrown.
"""
function fill_hole!(solver::Solver, path::Vector{Int}, rule_index::Int)
    #...
end
```

2. The `Hole` struct will be split up into two new concrete hole structs: `FixedShapedHole` and `VariableShapedHole`. The main difference between these two structs is that the domain of a fixed shaped hole contains only rules of exactly the same child types (e.g. `A -> A + B` and `A -> A * B` have the same childtypes. `A -> A + A` has different childtypes). The advantage of fixed shaped holes is that child nodes can already be instantiated before the concrete rule of the parent is known. This reduces the amount of trees that need to be stored in memory and can be exploited for stronger inference during constraint propagation.
