### PR TITLE
FixedShapedSolver

### DIFF
--- a/src/HerbCore.jl
+++ b/src/HerbCore.jl
@@ -25,7 +25,7 @@ export
     contains_variable_shaped_hole,
     get_children,
     get_rule,
-    has_children,
+    isfixedshaped,
     isfilled,
 
     Constraint,

--- a/src/HerbCore.jl
+++ b/src/HerbCore.jl
@@ -24,6 +24,9 @@ export
     contains_hole,
     contains_variable_shaped_hole,
     get_children,
+    get_rule,
+    has_children,
+    isfilled,
 
     Constraint,
     Grammar

--- a/src/HerbCore.jl
+++ b/src/HerbCore.jl
@@ -27,6 +27,7 @@ export
     get_rule,
     isfixedshaped,
     isfilled,
+    have_same_shape,
 
     Constraint,
     Grammar

--- a/src/rulenode.jl
+++ b/src/rulenode.jl
@@ -1,10 +1,10 @@
 """
-	AbstractRuleNode
+  abstract type AbstractRuleNode end
 
 Abstract type for representing expression trees.
-An AbstractRuleNode is expected to implement the following functions:
+An `AbstractRuleNode` is expected to implement the following functions:
 
-- `isfilled(::AbstractRuleNode)::Bool`. True iff the grammar rule this node holds is not ambiguous.
+- `isfilled(::AbstractRuleNode)::Bool`. True iff the grammar rule this node holds is not ambiguous, i.e. has domain size 1.
 - `isfixedshaped(::AbstractRuleNode)::Bool`. True iff the children of this node are known.
 - `get_rule(::AbstractRuleNode)::Int`. Returns the index of the grammar rule it represents.
 - `get_children(::AbstractRuleNode)::Vector{AbstractRuleNode}`. Returns the children of this node.
@@ -12,7 +12,7 @@ An AbstractRuleNode is expected to implement the following functions:
 Expression trees consist of [`RuleNode`](@ref)s and [`Hole`](@ref)s.
 
 - A [`RuleNode`](@ref) represents a certain production rule in the [`Grammar`](@ref).
-- A [`Hole`](@ref) is a placeholder where certain rules in the grammar still can be applied. 
+- A [`Hole`](@ref) is a placeholder where certain rules in the grammar still can be applied.
 """
 abstract type AbstractRuleNode end
 
@@ -43,7 +43,7 @@ end
 
 A [`Hole`](@ref) is a placeholder where certain rules from the grammar can still be applied.
 The `domain` of a [`Hole`](@ref) defines which rules can be applied.
-The `domain` is a bitvector, where the `i`th bit is set to true if the `i`th rule in the grammar can be applied. 
+The `domain` is a bitvector, where the `i`th bit is set to true if the `i`th rule in the grammar can be applied.
 """
 abstract type Hole <: AbstractRuleNode end
 
@@ -94,23 +94,23 @@ RuleNode(ind::Int, children::Vector{<:AbstractRuleNode}) = RuleNode(ind, nothing
 """
 	RuleNode(ind::Int, _val::Any)
 
-Create a [`RuleNode`](@ref) for the [`Grammar`](@ref) rule with index `ind`, 
+Create a [`RuleNode`](@ref) for the [`Grammar`](@ref) rule with index `ind`,
 `_val` as immediately evaluated value and no children
 
 !!! warning
 	Only use this constructor if you are absolutely certain that a rule is terminal and cannot have children.
 	Use [`RuleNode(ind::Int, grammar::Grammar)`] for rules that might have children.
-	In general, [`Hole`](@ref)s should be used as a placeholder when the children of a node are not yet known.   
+	In general, [`Hole`](@ref)s should be used as a placeholder when the children of a node are not yet known.
 
 !!! compat
 	Evaluate immediately functionality is not yet supported by most of Herb.jl.
 """
 RuleNode(ind::Int, _val::Any) = RuleNode(ind, _val, AbstractRuleNode[])
-    
+
 Base.:(==)(::RuleNode, ::Hole) = false
 Base.:(==)(::Hole, ::RuleNode) = false
-Base.:(==)(A::RuleNode, B::RuleNode) = 
-	(A.ind == B.ind) && 
+Base.:(==)(A::RuleNode, B::RuleNode) =
+	(A.ind == B.ind) &&
 	length(A.children) == length(B.children) && #required because zip doesn't check lengths
 	all(isequal(a, b) for (a, b) ∈ zip(A.children, B.children))
 # We do not know how the holes will be expanded yet, so we cannot assume equality even if the domains are equal.
@@ -191,8 +191,8 @@ Base.length(::VariableShapedHole) = 1
 	Base.isless(rn₁::AbstractRuleNode, rn₂::AbstractRuleNode)::Bool
 
 Compares two [`RuleNode`](@ref)s. Returns true if the left [`RuleNode`](@ref) is less than the right [`RuleNode`](@ref).
-Order is determined from the index of the [`RuleNode`](@ref)s. 
-If both [`RuleNode`](@ref)s have the same index, a depth-first search is 
+Order is determined from the index of the [`RuleNode`](@ref)s.
+If both [`RuleNode`](@ref)s have the same index, a depth-first search is
 performed in both [`RuleNode`](@ref)s until nodes with a different index
 are found.
 """
@@ -298,7 +298,7 @@ end
 Replace child `i` of a node, a part of larger `expr`, with `new_expr`.
 """
 function swap_node(expr::RuleNode, node::RuleNode, child_index::Int, new_expr::RuleNode)
-	if expr == node 
+	if expr == node
 		node.children[child_index] = new_expr
 	else
 		for child ∈ expr.children
@@ -315,7 +315,7 @@ Extract the derivation sequence from a path (sequence of child indices) and an [
 If the path is deeper than the deepest node, it returns what it has.
 """
 function get_rulesequence(node::RuleNode, path::Vector{Int})
-	if node.ind == 0 # sign for empty node 
+	if node.ind == 0 # sign for empty node
 		return Vector{Int}()
 	elseif isempty(node.children) # no childnen, nowehere to follow the path; still return the index
 		return [node.ind]
@@ -349,14 +349,14 @@ function rulesonleft(expr::RuleNode, path::Vector{Int})
 		for ch in expr.children
 			union!(ruleset, rulesonleft(ch, Vector{Int}()))
 		end
-		return ruleset 
+		return ruleset
 	elseif length(path) == 1
 		# if there is only one element left in the path, collect all children except the one indicated in the path
 		ruleset = Set{Int}(expr.ind)
 		for i in 1:path[begin]-1
 			union!(ruleset, rulesonleft(expr.children[i], Vector{Int}()))
 		end
-		return ruleset 
+		return ruleset
 	else
 		# collect all subtrees up to the child indexed in the path
 		ruleset = Set{Int}(expr.ind)
@@ -364,7 +364,7 @@ function rulesonleft(expr::RuleNode, path::Vector{Int})
 			union!(ruleset, rulesonleft(expr.children[i], Vector{Int}()))
 		end
 		union!(ruleset, rulesonleft(expr.children[path[begin]], path[2:end]))
-		return ruleset 
+		return ruleset
 	end
 end
 
@@ -374,7 +374,7 @@ rulesonleft(h::Hole, loc::Vector{Int}) = Set{Int}(findall(h.domain))
 """
 	get_node_at_location(root::RuleNode, location::Vector{Int})
 
-Retrieves a [`RuleNode`](@ref) at the given location by reference. 
+Retrieves a [`RuleNode`](@ref) at the given location by reference.
 """
 function get_node_at_location(root::AbstractRuleNode, location::Vector{Int})
     if location == []
@@ -465,7 +465,7 @@ isfixedshaped(::FixedShapedHole)::Bool = true
 """
 	isfilled(node::AbstractRuleNode)::Bool
 
-Returns whether the [`AbstractRuleNode`] holds a single rule.
+Returns whether the [`AbstractRuleNode`] holds a single rule. This is always the case for [`RuleNode`](@ref)s.
 Holes are considered to be "filled" iff their domain size is exactly 1.
 """
 isfilled(rn::RuleNode)::Bool = true

--- a/src/rulenode.jl
+++ b/src/rulenode.jl
@@ -484,3 +484,33 @@ function get_rule(hole::Hole)
 	return findfirst(hole.domain)
 end
 
+"""
+	have_same_shape(node1::AbstractRuleNode, node2::AbstractRuleNode)
+
+Returns true iff `node1` and `node2` have the same shape
+Example:
+RuleNode(3, [
+	RuleNode(1),
+	RuleNode(1)
+]) and
+RuleNode(9, [
+	RuleNode(2),
+	VariableShapedHole(domain)
+])
+have the same shape: 1 root with 2 children.
+"""
+function have_same_shape(node1, node2)
+	children1 = get_children(node1)
+	children2 = get_children(node2)
+	if length(children1) != length(children2)
+		return false
+	end
+	if length(children1) > 0
+		for (child1, child2) ∈ zip(children1, children2)
+			if !have_same_shape(child1, child2)
+				return false
+			end
+		end
+	end
+	return true
+end

--- a/src/rulenode.jl
+++ b/src/rulenode.jl
@@ -430,6 +430,43 @@ Checks if an [`AbstractRuleNode`](@ref) tree contains a [`VariableShapedHole`](@
 contains_variable_shaped_hole(rn::AbstractRuleNode) = any(contains_variable_shaped_hole(c) for c ∈ rn.children)
 contains_variable_shaped_hole(hole::VariableShapedHole) = true
 
+"""
+	get_children(rn::AbstractRuleNode)
+
+Returns the children of the given [`AbstractRuleNode`](@ref)
+"""
 get_children(rn::RuleNode)::Vector{AbstractRuleNode} = rn.children
 get_children(::VariableShapedHole)::Vector{AbstractRuleNode} = []
 get_children(h::FixedShapedHole)::Vector{AbstractRuleNode} = h.children
+
+"""
+	has_children(rn::AbstractRuleNode)
+
+Returns true if the [`AbstractRuleNode`](@ref) has 1 or more children.
+"""
+has_children(rn::RuleNode)::Bool = (length(rn.children) > 0)
+has_children(::VariableShapedHole)::Bool = false
+has_children(hole::FixedShapedHole)::Bool = (length(hole.children) > 0)
+
+"""
+	isfilled(node::AbstractRuleNode)::Bool
+
+Returns whether the [`AbstractRuleNode`] holds a single rule.
+Holes are considered to be "filled" iff their domain size is exactly 1.
+"""
+isfilled(rn::RuleNode)::Bool = true
+isfilled(hole::FixedShapedHole)::Bool = (sum(hole.domain) == 1)
+isfilled(hole::VariableShapedHole)::Bool = (sum(hole.domain) == 1)
+
+
+"""
+	get_rule(rn::AbstractRuleNode)
+
+Returns the index of the rule that this [`AbstractRuleNode`](@ref) represents
+"""
+get_rule(rn::RuleNode) = rn.ind
+function get_rule(hole::Hole)
+	@assert isfilled(hole) "$(hole) is not filled, unable to get the rule"
+	return findfirst(hole.domain)
+end
+

--- a/src/rulenode.jl
+++ b/src/rulenode.jl
@@ -2,6 +2,13 @@
 	AbstractRuleNode
 
 Abstract type for representing expression trees.
+An AbstractRuleNode is expected to implement the following functions:
+
+- `isfilled(::AbstractRuleNode)::Bool`. True iff the grammar rule this node holds is not ambiguous.
+- `isfixedshaped(::AbstractRuleNode)::Bool`. True iff the children of this node are known.
+- `get_rule(::AbstractRuleNode)::Int`. Returns the index of the grammar rule it represents.
+- `get_children(::AbstractRuleNode)::Vector{AbstractRuleNode}`. Returns the children of this node.
+
 Expression trees consist of [`RuleNode`](@ref)s and [`Hole`](@ref)s.
 
 - A [`RuleNode`](@ref) represents a certain production rule in the [`Grammar`](@ref).
@@ -430,23 +437,30 @@ Checks if an [`AbstractRuleNode`](@ref) tree contains a [`VariableShapedHole`](@
 contains_variable_shaped_hole(rn::AbstractRuleNode) = any(contains_variable_shaped_hole(c) for c ∈ rn.children)
 contains_variable_shaped_hole(hole::VariableShapedHole) = true
 
+
+#Shared reference to an empty vector to reduce memory allocations.
+NOCHILDREN = Vector{AbstractRuleNode}()
+
+
 """
 	get_children(rn::AbstractRuleNode)
 
 Returns the children of the given [`AbstractRuleNode`](@ref)
 """
-get_children(rn::RuleNode)::Vector{AbstractRuleNode} = rn.children
-get_children(::VariableShapedHole)::Vector{AbstractRuleNode} = []
+get_children(rn::AbstractRuleNode)::Vector{AbstractRuleNode} = rn.children
+get_children(::VariableShapedHole)::Vector{AbstractRuleNode} = NOCHILDREN
 get_children(h::FixedShapedHole)::Vector{AbstractRuleNode} = h.children
 
-"""
-	has_children(rn::AbstractRuleNode)
 
-Returns true if the [`AbstractRuleNode`](@ref) has 1 or more children.
 """
-has_children(rn::RuleNode)::Bool = (length(rn.children) > 0)
-has_children(::VariableShapedHole)::Bool = false
-has_children(hole::FixedShapedHole)::Bool = (length(hole.children) > 0)
+	isfixedshaped(rn::AbstractRuleNode)
+
+Returns true iff the children of the [`AbstractRuleNode`](@ref) are known.
+"""
+isfixedshaped(::RuleNode)::Bool = true
+isfixedshaped(::VariableShapedHole)::Bool = false
+isfixedshaped(::FixedShapedHole)::Bool = true
+
 
 """
 	isfilled(node::AbstractRuleNode)::Bool

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -184,5 +184,36 @@ using Test
             @test get_rule(FixedShapedHole(domain_of_size_1, [RuleNode(5), RuleNode(6)])) == 2
             @test get_rule(VariableShapedHole(domain_of_size_1)) == 2
         end
+
+        @testset "have_same_shape" begin
+            domain = BitVector((1, 1, 1, 1, 1, 1, 1, 1, 1))
+            @test have_same_shape(RuleNode(1), RuleNode(2))
+            @test have_same_shape(RuleNode(1), VariableShapedHole(domain))
+            @test have_same_shape(RuleNode(1), RuleNode(4, [RuleNode(1)])) == false
+            @test have_same_shape(RuleNode(4, [RuleNode(1)]), RuleNode(1)) == false
+
+            node1 = RuleNode(3, [
+                RuleNode(1),
+                RuleNode(1)
+            ])
+            node2 = RuleNode(9, [
+                RuleNode(2),
+                VariableShapedHole(domain)
+            ])
+            @test have_same_shape(node1, node2)
+
+            node1 = RuleNode(3, [
+                RuleNode(1),
+                RuleNode(1)
+            ])
+            node2 = RuleNode(9, [
+                RuleNode(2),
+                RuleNode(3, [
+                    RuleNode(1),
+                    RuleNode(1)
+                ])
+            ])
+            @test have_same_shape(node1, node2) == false
+        end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -149,17 +149,17 @@ using Test
             ])) == 4
         end
 
-        @testset "has_children" begin
+        @testset "isfixedshaped" begin
             domain=BitVector((1, 1))
 
-            @test has_children(RuleNode(1, [RuleNode(2)])) == true
-            @test has_children(FixedShapedHole(domain, [RuleNode(2)])) == true
+            @test isfixedshaped(RuleNode(1, [RuleNode(2)])) == true
+            @test isfixedshaped(FixedShapedHole(domain, [RuleNode(2)])) == true
 
-            @test has_children(RuleNode(1)) == false
-            @test has_children(RuleNode(1, [])) == false
-            @test has_children(FixedShapedHole(domain, [])) == false
+            @test isfixedshaped(RuleNode(1)) == true
+            @test isfixedshaped(RuleNode(1, [])) == true
+            @test isfixedshaped(FixedShapedHole(domain, [])) == true
 
-            @test has_children(VariableShapedHole(domain)) == false
+            @test isfixedshaped(VariableShapedHole(domain)) == false
         end
 
         @testset "isfilled" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -148,5 +148,41 @@ using Test
                 FixedShapedHole(domain, [VariableShapedHole(domain), RuleNode(1)])
             ])) == 4
         end
+
+        @testset "has_children" begin
+            domain=BitVector((1, 1))
+
+            @test has_children(RuleNode(1, [RuleNode(2)])) == true
+            @test has_children(FixedShapedHole(domain, [RuleNode(2)])) == true
+
+            @test has_children(RuleNode(1)) == false
+            @test has_children(RuleNode(1, [])) == false
+            @test has_children(FixedShapedHole(domain, [])) == false
+
+            @test has_children(VariableShapedHole(domain)) == false
+        end
+
+        @testset "isfilled" begin
+            domain1=BitVector((0, 1, 0, 0, 0))
+            domain2=BitVector((0, 1, 0, 1, 0))
+            @test isfilled(RuleNode(1, [])) == true
+            @test isfilled(RuleNode(1, [RuleNode(2)])) == true
+            @test isfilled(RuleNode(1, [VariableShapedHole(domain1)])) == true
+            @test isfilled(RuleNode(1, [VariableShapedHole(domain2)])) == true
+
+            @test isfilled(FixedShapedHole(domain1, [VariableShapedHole(domain2)])) == true
+            @test isfilled(FixedShapedHole(domain2, [VariableShapedHole(domain2)])) == false
+
+            @test isfilled(VariableShapedHole(domain1)) == true
+            @test isfilled(VariableShapedHole(domain2)) == false
+        end
+
+        @testset "get_rule" begin
+            domain_of_size_1=BitVector((0, 1, 0, 0, 0))
+            @test get_rule(RuleNode(99, [RuleNode(3), RuleNode(4)])) == 99
+            @test get_rule(RuleNode(2, [RuleNode(3), RuleNode(4)])) == 2
+            @test get_rule(FixedShapedHole(domain_of_size_1, [RuleNode(5), RuleNode(6)])) == 2
+            @test get_rule(VariableShapedHole(domain_of_size_1)) == 2
+        end
     end
 end


### PR DESCRIPTION
Adds two types of solvers:
* `FixedShapedSolver`. This solver is more memory efficient, but only works on fixed shaped trees. It enumerates all solutions of a fixed shaped tree by (re)assigning the values of holes. To achieve this, it uses a new fixed shaped hole type with stateful domains.
* `GenericSolver`. This solver has more flexible state management. It treats each state as an independent propagation program. Iterators can use `save_state!` and `load_state!` to switch between states at any time.