### PR TITLE
Stochastic using solver (4 PRs)

### DIFF
--- a/src/HerbCore.jl
+++ b/src/HerbCore.jl
@@ -27,6 +27,7 @@ export
     get_rule,
     isfixedshaped,
     isfilled,
+    hasdynamicvalue,
     have_same_shape,
 
     AbstractConstraint,

--- a/src/HerbCore.jl
+++ b/src/HerbCore.jl
@@ -29,7 +29,7 @@ export
     isfilled,
     have_same_shape,
 
-    Constraint,
+    AbstractConstraint,
     AbstractGrammar
 
 end # module HerbCore

--- a/src/constraint.jl
+++ b/src/constraint.jl
@@ -2,4 +2,4 @@
 Represents a constraint for a [`ContextSensitiveGrammar`](@ref).
 Concrete implementations can be found in HerbConstraints.jl.
 """
-abstract type Constraint end
+abstract type AbstractConstraint end

--- a/src/rulenode.jl
+++ b/src/rulenode.jl
@@ -194,7 +194,7 @@ Base.isless(rn₁::AbstractRuleNode, rn₂::AbstractRuleNode)::Bool = _rulenode_
 function _rulenode_compare(rn₁::AbstractRuleNode, rn₂::AbstractRuleNode)::Int
     # Helper function for Base.isless
     if !isfilled(rn₁) || !isfilled(rn₂)
-        throw("BadArgument: unable to compare nodes of types ($(typeof(rn₁)), $(typeof(rn₂)))")
+        throw(ArgumentError("Unable to compare nodes of types ($(typeof(rn₁)), $(typeof(rn₂)))"))
     end
     if get_rule(rn₁) == get_rule(rn₂)
         for (c₁, c₂) ∈ zip(rn₁.children, rn₂.children)

--- a/src/rulenode.jl
+++ b/src/rulenode.jl
@@ -169,22 +169,14 @@ end
     Base.length(root::RuleNode)
 
 Return the number of nodes in the tree rooted at root.
-Holes don't count.
 """
-function Base.length(root::Union{RuleNode, FixedShapedHole})
+function Base.length(root::AbstractRuleNode)
     retval = 1
-    for c in root.children
+    for c in get_children(root)
         retval += length(c)
     end
     return retval
 end
-
-"""
-    Base.length(root::VariableShapedHole)
-
-Return the number of nodes in the tree rooted at root.
-Holes do count.
-"""
 Base.length(::VariableShapedHole) = 1
 
 """
@@ -199,9 +191,12 @@ are found.
 Base.isless(rn₁::AbstractRuleNode, rn₂::AbstractRuleNode)::Bool = _rulenode_compare(rn₁, rn₂) == -1
 
 
-function _rulenode_compare(rn₁::RuleNode, rn₂::RuleNode)::Int
+function _rulenode_compare(rn₁::AbstractRuleNode, rn₂::AbstractRuleNode)::Int
     # Helper function for Base.isless
-    if rn₁.ind == rn₂.ind
+    if !isfilled(rn₁) || !isfilled(rn₂)
+        throw("BadArgument: unable to compare nodes of types ($(typeof(rn₁)), $(typeof(rn₂)))")
+    end
+    if get_rule(rn₁) == get_rule(rn₂)
         for (c₁, c₂) ∈ zip(rn₁.children, rn₂.children)
             comparison = _rulenode_compare(c₁, c₂)
             if comparison ≠ 0
@@ -210,13 +205,9 @@ function _rulenode_compare(rn₁::RuleNode, rn₂::RuleNode)::Int
         end
         return 0
     else
-        return rn₁.ind < rn₂.ind ? -1 : 1
+        return get_rule(rn₁) < get_rule(rn₂) ? -1 : 1
     end
 end
-
-_rulenode_compare(::Hole, ::RuleNode) = -1
-_rulenode_compare(::RuleNode, ::Hole) = 1
-_rulenode_compare(::Hole, ::Hole) = 0
 
 
 """
@@ -476,6 +467,15 @@ Holes are considered to be "filled" iff their domain size is exactly 1.
 isfilled(rn::RuleNode)::Bool = true
 isfilled(hole::FixedShapedHole)::Bool = (sum(hole.domain) == 1)
 isfilled(hole::VariableShapedHole)::Bool = (sum(hole.domain) == 1)
+
+
+"""
+    function hasdynamicvalue(rn::AbstractRuleNode)::Bool
+
+Returns true iff the rule has a `_val` field set up.
+"""
+hasdynamicvalue(rn::RuleNode)::Bool = !isnothing(rn._val)
+hasdynamicvalue(rn::AbstractRuleNode)::Bool = false
 
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -40,6 +40,8 @@ using Test
             @test RuleNode(2) > RuleNode(1) 
             @test RuleNode(1,[RuleNode(2)]) < RuleNode(1,[RuleNode(3)]) 
             @test RuleNode(1,[RuleNode(2)]) < RuleNode(2,[RuleNode(1)]) 
+            @test_throws ArgumentError RuleNode(1) < VariableShapedHole(BitVector((1, 1)))
+            @test_throws ArgumentError VariableShapedHole(BitVector((1, 1))) < RuleNode(1)
         end
 
         @testset "Node depth from a tree" begin 
@@ -214,6 +216,14 @@ using Test
                 ])
             ])
             @test have_same_shape(node1, node2) == false
+        end
+
+        @testset "hasdynamicvalue" begin
+            @test hasdynamicvalue(RuleNode(1, "DynamicValue")) == true
+            @test hasdynamicvalue(RuleNode(1)) == false
+            @test hasdynamicvalue(FixedShapedHole(BitVector((1, 0)), [RuleNode(1, "DynamicValue")])) == false
+            @test hasdynamicvalue(FixedShapedHole(BitVector((1, 0)), [RuleNode(1)])) == false
+            @test hasdynamicvalue(VariableShapedHole(BitVector((1, 0)))) == false
         end
     end
 end


### PR DESCRIPTION
`hasdynamicvalue` is needed for the `rulenode2expr` function in HerbGrammar. If an `AbstractRuleNode` does not have an `_eval` field set up, then functionality related to this cached/dynamic value should be ignored.