### PR TITLE
Remove broken references

### DIFF
--- a/src/constraint.jl
+++ b/src/constraint.jl
@@ -1,5 +1,5 @@
 """
-Represents a constraint for a `ContextSensitiveGrammar`.
+Represents a constraint for a [`AbstractGrammar`](@ref).
 Concrete implementations can be found in HerbConstraints.jl.
 """
 abstract type Constraint end

--- a/src/constraint.jl
+++ b/src/constraint.jl
@@ -1,5 +1,5 @@
 """
-Represents a constraint for a [`ContextSensitiveGrammar`](@ref).
+Represents a constraint for a `ContextSensitiveGrammar`.
 Concrete implementations can be found in HerbConstraints.jl.
 """
 abstract type Constraint end

--- a/src/grammar.jl
+++ b/src/grammar.jl
@@ -16,6 +16,6 @@ If a rule is terminal, the corresponding list is empty.
 - `log_probabilities::Union{Vector{Real}, Nothing}`: A list of probabilities for each rule. 
 If the grammar is non-probabilistic, the list can be `nothing`.
 
-For concrete types, see [`ContextSensitiveGrammar`](@ref) within the `HerbGrammar` module.
+For concrete types, see `ContextSensitiveGrammar` within the `HerbGrammar` module.
 """
 abstract type AbstractGrammar end


### PR DESCRIPTION
Removes `@ref` to `HerbGrammar` which doesn't work due to circular dependency: We would need to import `HerbGrammar` for reference to work, but we can't do that since `HerbGrammar` depends on `HerbCore`.

Partly addresses [#61](https://github.com/Herb-AI/Herb.jl/issues/61).