### PR TITLE
Renaming hole functions

### DIFF
--- a/src/HerbCore.jl
+++ b/src/HerbCore.jl
@@ -20,7 +20,7 @@ export
        get_node_path,
        number_of_holes,
        contains_hole,
-       contains_variable_shaped_hole,
+       contains_nonuniform_hole,
        get_children,
        get_rule,
        isuniform,

--- a/src/HerbCore.jl
+++ b/src/HerbCore.jl
@@ -23,7 +23,7 @@ export
        contains_variable_shaped_hole,
        get_children,
        get_rule,
-       isfixedshaped,
+       isuniform,
        isfilled,
        hasdynamicvalue,
        have_same_shape, AbstractConstraint,

--- a/src/rulenode.jl
+++ b/src/rulenode.jl
@@ -5,7 +5,7 @@ Abstract type for representing expression trees.
 An `AbstractRuleNode` is expected to implement the following functions:
 
 - `isfilled(::AbstractRuleNode)::Bool`. True iff the grammar rule this node holds is not ambiguous, i.e. has domain size 1.
-- `isfixedshaped(::AbstractRuleNode)::Bool`. True iff the children of this node are known.
+- `isuniform(::AbstractRuleNode)::Bool`. True iff the children of this node are known.
 - `get_rule(::AbstractRuleNode)::Int`. Returns the index of the grammar rule it represents.
 - `get_children(::AbstractRuleNode)::Vector{AbstractRuleNode}`. Returns the children of this node.
 
@@ -439,13 +439,13 @@ get_children(::Hole)::Vector{AbstractRuleNode} = NOCHILDREN
 get_children(h::UniformHole)::Vector{AbstractRuleNode} = h.children
 
 """
-	isfixedshaped(rn::AbstractRuleNode)
+	isuniform(rn::AbstractRuleNode)
 
 Returns true iff the children of the [`AbstractRuleNode`](@ref) are known.
 """
-isfixedshaped(::RuleNode)::Bool = true
-isfixedshaped(::Hole)::Bool = false
-isfixedshaped(::UniformHole)::Bool = true
+isuniform(::RuleNode)::Bool = true
+isuniform(::Hole)::Bool = false
+isuniform(::UniformHole)::Bool = true
 
 """
 	isfilled(node::AbstractRuleNode)::Bool

--- a/src/rulenode.jl
+++ b/src/rulenode.jl
@@ -418,13 +418,13 @@ contains_hole(rn::RuleNode) = any(contains_hole(c) for c in rn.children)
 contains_hole(hole::AbstractHole) = true
 
 """
-    contains_variable_shaped_hole(rn::RuleNode)
+    contains_nonuniform_hole(rn::RuleNode)
 
 Checks if an [`AbstractRuleNode`](@ref) tree contains a [`Hole`](@ref).
 """
-contains_variable_shaped_hole(rn::AbstractRuleNode) = any(contains_variable_shaped_hole(c)
+contains_nonuniform_hole(rn::AbstractRuleNode) = any(contains_nonuniform_hole(c)
 for c in rn.children)
-contains_variable_shaped_hole(hole::Hole) = true
+contains_nonuniform_hole(hole::Hole) = true
 
 #Shared reference to an empty vector to reduce memory allocations.
 NOCHILDREN = Vector{AbstractRuleNode}()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -153,17 +153,17 @@ using Test
                 ])) == 4
         end
 
-        @testset "isfixedshaped" begin
+        @testset "isuniform" begin
             domain = BitVector((1, 1))
 
-            @test isfixedshaped(RuleNode(1, [RuleNode(2)])) == true
-            @test isfixedshaped(UniformHole(domain, [RuleNode(2)])) == true
+            @test isuniform(RuleNode(1, [RuleNode(2)])) == true
+            @test isuniform(UniformHole(domain, [RuleNode(2)])) == true
 
-            @test isfixedshaped(RuleNode(1)) == true
-            @test isfixedshaped(RuleNode(1, [])) == true
-            @test isfixedshaped(UniformHole(domain, [])) == true
+            @test isuniform(RuleNode(1)) == true
+            @test isuniform(RuleNode(1, [])) == true
+            @test isuniform(UniformHole(domain, [])) == true
 
-            @test isfixedshaped(Hole(domain)) == false
+            @test isuniform(Hole(domain)) == false
         end
 
         @testset "isfilled" begin


### PR DESCRIPTION
Rename the following to match the renamed types:

- `isfixedshaped` -> `isuniform`
- `contains_variable_shaped_hole` -> `contains_nonuniform_hole`