### PR TITLE
Address Aqua type piracy errors

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,9 +1,13 @@
 name = "HerbCore"
 uuid = "2b23ba43-8213-43cb-b5ea-38c12b45bd45"
 authors = ["Jaap de Jong <jaapdejong15@gmail.com>", "Nicolae Filat <N.Filat@student.tudelft.nl>", "Tilman Hinnerichs <t.r.hinnerichs@tudelft.nl>", "Sebastijan Dumancic <s.dumancic@tudelft.nl>"]
-version = "0.3.2"
+version = "0.3.3"
+
+[deps]
+AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
 
 [compat]
+AbstractTrees = "0.4.5"
 julia = "^1.8"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -9,9 +9,3 @@ AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
 [compat]
 AbstractTrees = "0.4.5"
 julia = "^1.8"
-
-[extras]
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-
-[targets]
-test = ["Test"]

--- a/src/HerbCore.jl
+++ b/src/HerbCore.jl
@@ -32,4 +32,8 @@ export
        have_same_shape, AbstractConstraint,
        AbstractGrammar
 
+# AbstractTrees interface
+children,
+nodevalue
+
 end # module HerbCore

--- a/src/HerbCore.jl
+++ b/src/HerbCore.jl
@@ -32,8 +32,4 @@ export
        have_same_shape, AbstractConstraint,
        AbstractGrammar
 
-# AbstractTrees interface
-children,
-nodevalue
-
 end # module HerbCore

--- a/src/HerbCore.jl
+++ b/src/HerbCore.jl
@@ -1,8 +1,10 @@
 module HerbCore
 
+using AbstractTrees
+
+include("grammar.jl")
 include("rulenode.jl")
 include("constraint.jl")
-include("grammar.jl")
 
 export
        AbstractRuleNode,

--- a/src/grammar.jl
+++ b/src/grammar.jl
@@ -19,3 +19,11 @@ If the grammar is non-probabilistic, the list can be `nothing`.
 For concrete types, see `ContextSensitiveGrammar` within the `HerbGrammar` module.
 """
 abstract type AbstractGrammar end
+
+function Base.show(io::IO, grammar::AbstractGrammar)
+    for i in eachindex(grammar.rules)
+        println(io, i, ": ", grammar.types[i], " = ", grammar.rules[i])
+    end
+end
+
+Base.getindex(grammar::AbstractGrammar, typ::Symbol) = grammar.bytype[typ]

--- a/src/rulenode.jl
+++ b/src/rulenode.jl
@@ -40,16 +40,6 @@ mutable struct RuleNode <: AbstractRuleNode
     children::Vector{AbstractRuleNode}
 end
 
-function RuleNode(ind::Int, grammar::AbstractGrammar)
-    RuleNode(
-        ind, nothing, [Hole(get_domain(grammar, type)) for type in grammar.childtypes[ind]])
-end
-
-function RuleNode(ind::Int, _val::Any, grammar::AbstractGrammar)
-    RuleNode(
-        ind, _val, [Hole(get_domain(grammar, type)) for type in grammar.childtypes[ind]])
-end
-
 """
     AbstractHole <: AbstractRuleNode
 
@@ -76,11 +66,6 @@ abstract type AbstractUniformHole <: AbstractHole end
 mutable struct UniformHole <: AbstractUniformHole
     domain::BitVector
     children::Vector{AbstractRuleNode}
-end
-
-function UniformHole(domain::BitVector, grammar::AbstractGrammar)
-    UniformHole(domain,
-        [Hole(get_domain(grammar, type)) for type in grammar.childtypes[findfirst(domain)]])
 end
 
 """

--- a/src/rulenode.jl
+++ b/src/rulenode.jl
@@ -16,6 +16,10 @@ Expression trees consist of [`RuleNode`](@ref)s and [`AbstractHole`](@ref)s.
 """
 abstract type AbstractRuleNode end
 
+# Interface to AbstractTrees.jl
+AbstractTrees.children(node::AbstractRuleNode) = get_children(node)
+AbstractTrees.nodevalue(node::AbstractRuleNode) = get_rule(node)
+
 """
     RuleNode <: AbstractRuleNode
 
@@ -34,6 +38,16 @@ mutable struct RuleNode <: AbstractRuleNode
     ind::Int # index in grammar
     _val::Any  #value of _() evals
     children::Vector{AbstractRuleNode}
+end
+
+function RuleNode(ind::Int, grammar::AbstractGrammar)
+    RuleNode(
+        ind, nothing, [Hole(get_domain(grammar, type)) for type in grammar.childtypes[ind]])
+end
+
+function RuleNode(ind::Int, _val::Any, grammar::AbstractGrammar)
+    RuleNode(
+        ind, _val, [Hole(get_domain(grammar, type)) for type in grammar.childtypes[ind]])
 end
 
 """
@@ -62,6 +76,11 @@ abstract type AbstractUniformHole <: AbstractHole end
 mutable struct UniformHole <: AbstractUniformHole
     domain::BitVector
     children::Vector{AbstractRuleNode}
+end
+
+function UniformHole(domain::BitVector, grammar::AbstractGrammar)
+    UniformHole(domain,
+        [Hole(get_domain(grammar, type)) for type in grammar.childtypes[findfirst(domain)]])
 end
 
 """

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,0 +1,3 @@
+[deps]
+AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,3 +1,4 @@
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,3 +1,4 @@
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
+HerbGrammar = "4ef9e186-2fe5-4b24-8de7-9f7291f24af7"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,3 @@
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
-HerbGrammar = "4ef9e186-2fe5-4b24-8de7-9f7291f24af7"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,11 +1,9 @@
 using AbstractTrees: children, nodevalue, treeheight
 using HerbCore
-using HerbGrammar: @csgrammar
 using Test
 
 @testset "HerbCore.jl" verbose=true begin
     @testset "AbstractTrees Interface" begin
-        @show typeof(nodevalue(RuleNode(1)))
         @test nodevalue(RuleNode(1)) == 1
         @test isempty(children(RuleNode(1)))
         @test length(children(RuleNode(1, [RuleNode(2), RuleNode(2)]))) == 2
@@ -348,9 +346,15 @@ using Test
     end
 
     @testset "Grammar" begin
-        g = @csgrammar begin
-            A = 1
+        struct ExGrammar <: AbstractGrammar
+            rules::Vector{Any}
+            types::Vector{Symbol}
+            # ...
+            # only partially implementing the AbstractGrammar interface
+            # to test the Base.show
         end
+
+        g = ExGrammar([1], [:A])
 
         io = IOBuffer()
         Base.show(io, g)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,17 @@
+using AbstractTrees: children, nodevalue, treeheight
 using HerbCore
 using Test
 
 @testset "HerbCore.jl" verbose=true begin
+    @testset "AbstractTrees Interface" begin
+        @show typeof(nodevalue(RuleNode(1)))
+        @test nodevalue(RuleNode(1)) == 1
+        @test isempty(children(RuleNode(1)))
+        @test length(children(RuleNode(1, [RuleNode(2), RuleNode(2)]))) == 2
+        @test treeheight(RuleNode(1)) == 0
+        @test treeheight(RuleNode(1, [RuleNode(2), RuleNode(2)])) == 1
+    end
+
     @testset "RuleNode tests" begin
         @testset "Equality tests" begin
             @test RuleNode(1) == RuleNode(1)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using AbstractTrees: children, nodevalue, treeheight
 using HerbCore
+using HerbGrammar: @csgrammar
 using Test
 
 @testset "HerbCore.jl" verbose=true begin
@@ -344,5 +345,15 @@ using Test
             @test String(take!(io)) ==
                   "12{14,2{4{hole[Bool[1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]]}},2{4{6}}}"
         end
+    end
+
+    @testset "Grammar" begin
+        g = @csgrammar begin
+            A = 1
+        end
+
+        io = IOBuffer()
+        Base.show(io, g)
+        @test String(take!(io)) == "1: A = 1\n"
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,11 @@
 using AbstractTrees: children, nodevalue, treeheight
+using Aqua
 using HerbCore
 using Test
 
 @testset "HerbCore.jl" verbose=true begin
+    @testset "Aqua Tests" Aqua.test_all(HerbCore)
+
     @testset "AbstractTrees Interface" begin
         @test nodevalue(RuleNode(1)) == 1
         @test isempty(children(RuleNode(1)))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -349,15 +349,22 @@ using Test
         struct ExGrammar <: AbstractGrammar
             rules::Vector{Any}
             types::Vector{Symbol}
+            bytype::Dict{Symbol, Vector{Int}}
             # ...
             # only partially implementing the AbstractGrammar interface
             # to test the Base.show
         end
 
-        g = ExGrammar([1], [:A])
+        g = ExGrammar([1], [:A], Dict([:A => [1]]))
 
-        io = IOBuffer()
-        Base.show(io, g)
-        @test String(take!(io)) == "1: A = 1\n"
+        @testset "show" begin
+            io = IOBuffer()
+            Base.show(io, g)
+            @test String(take!(io)) == "1: A = 1\n"
+        end
+
+        @testset "get_index" begin
+            @test g[:A] == [1]
+        end
     end
 end


### PR DESCRIPTION
The following methods from `HerbGrammar` were picked up by `Aqua` as pirated. They should be defined here because their input arguments are all types defined here in `HerbCore`.

<details><summary>The interface to AbstractTrees.jl</summary>
<p>

https://github.com/Herb-AI/HerbCore.jl/blob/1bf674ce9b446075c2803f075c8508156f4f5554/src/rulenode.jl#L19-L21

</p>
</details> 

<details><summary>These RuleNode/Hole Constructors</summary>
<p>

https://github.com/Herb-AI/HerbCore.jl/blob/1bf674ce9b446075c2803f075c8508156f4f5554/src/rulenode.jl#L43

https://github.com/Herb-AI/HerbCore.jl/blob/1bf674ce9b446075c2803f075c8508156f4f5554/src/rulenode.jl#L48

https://github.com/Herb-AI/HerbCore.jl/blob/1bf674ce9b446075c2803f075c8508156f4f5554/src/rulenode.jl#L81

</p>
</details> 

<details><summary>Base.show and Base.getindex definitions for AbstractGrammars</summary>
<p>

https://github.com/Herb-AI/HerbCore.jl/blob/1bf674ce9b446075c2803f075c8508156f4f5554/src/grammar.jl#L23-L29

</p>
</details> 

Addresses https://github.com/Herb-AI/HerbGrammar.jl/issues/96 and https://github.com/Herb-AI/HerbGrammar.jl/issues/97.