### PR TITLE
Add explicit workflow permission.

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -20,6 +20,7 @@ permissions:
   repository-projects: read
   security-events: read
   statuses: read
+  workflows: write 
 jobs:
   TagBot:
     if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'


### PR DESCRIPTION
Add a explicit `write` permission for workflows to tagbot.yml.

