### PR TITLE
Revert "Add explicit workflow permission."

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -20,7 +20,6 @@ permissions:
   repository-projects: read
   security-events: read
   statuses: read
-  workflows: write 
 jobs:
   TagBot:
     if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'


### PR DESCRIPTION
Reverts Herb-AI/HerbCore.jl#33. Sorry, @pwochner, I should've checked in the online editor on Github. It looks like this key isn't valid for the `permissions` setting.