### PR TITLE
Re-export `print_tree`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "HerbCore"
 uuid = "2b23ba43-8213-43cb-b5ea-38c12b45bd45"
 authors = ["Jaap de Jong <jaapdejong15@gmail.com>", "Nicolae Filat <N.Filat@student.tudelft.nl>", "Tilman Hinnerichs <t.r.hinnerichs@tudelft.nl>", "Sebastijan Dumancic <s.dumancic@tudelft.nl>"]
-version = "0.3.5"
+version = "0.3.6"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/HerbCore.jl
+++ b/src/HerbCore.jl
@@ -32,6 +32,7 @@ export
        isfilled,
        hasdynamicvalue,
        have_same_shape, AbstractConstraint,
-       AbstractGrammar
+       AbstractGrammar,
+       print_tree
 
 end # module HerbCore


### PR DESCRIPTION
`print_tree` from `AbstractTrees` is sometimes useful for printing out `RuleNode`s in the form

```julia
julia> print_tree(rn)
1
├─ 2
└─ 3
```
instead of the usual `1{2,3}` that `Base.show(::RuleNode)` outputs.

I think it makes sense to re-export it here.