### PR TITLE
Update `Base.show` for holes, update tests to match

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "HerbCore"
 uuid = "2b23ba43-8213-43cb-b5ea-38c12b45bd45"
 authors = ["Jaap de Jong <jaapdejong15@gmail.com>", "Nicolae Filat <N.Filat@student.tudelft.nl>", "Tilman Hinnerichs <t.r.hinnerichs@tudelft.nl>", "Sebastijan Dumancic <s.dumancic@tudelft.nl>"]
-version = "0.3.6"
+version = "0.3.7"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/rulenode.jl
+++ b/src/rulenode.jl
@@ -180,33 +180,19 @@ end
 
 function Base.show(io::IO, node::RuleNode; separator = ",")
     print(io, node.ind)
-    if !isempty(node.children)
-        print(io, "{")
-        for (i, c) in enumerate(node.children)
-            show(io, c, separator = separator)
-            if i != length(node.children)
-                print(io, separator)
-            end
-        end
-        print(io, "}")
+    if !isempty(children(node))
+        Base.show_enclosed_list(io, "{", children(node), separator, "}", 0)
     end
 end
 
 function Base.show(io::IO, node::AbstractHole; _...)
-    print(io, "hole[$(node.domain)]")
+    print(io, "Hole[$(node.domain)]")
 end
 
 function Base.show(io::IO, node::UniformHole; separator = ",")
-    print(io, "fshole[$(node.domain)]")
+    print(io, "UniformHole[$(node.domain)]")
     if !isempty(node.children)
-        print(io, "{")
-        for (i, c) in enumerate(node.children)
-            show(io, c, separator = separator)
-            if i != length(node.children)
-                print(io, separator)
-            end
-        end
-        print(io, "}")
+        Base.show_enclosed_list(io, "{", children(node), separator, "}", 0)
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -279,7 +279,7 @@ using Test
 
     @testset "UniformHole" begin
         @testset "show" begin
-            # fshole[Bool[0, 0, 1]]{14,2{4{9}},2{4{6}}}
+            # UniformHole[Bool[0, 0, 1]]{14,2{4{9}},2{4{6}}}
             node = UniformHole([0, 0, 1],
                 [
                     RuleNode(14),
@@ -297,13 +297,13 @@ using Test
             )
             io = IOBuffer()
             Base.show(io, node)
-            @test String(take!(io)) == "fshole[Bool[0, 0, 1]]{14,2{4{9}},2{4{6}}}"
+            @test String(take!(io)) == "UniformHole[Bool[0, 0, 1]]{14,2{4{9}},2{4{6}}}"
         end
     end
 
     @testset "Hole" begin
         @testset "show" begin
-            # 12{14,2{4{hole[...]}},2{4{6}}}
+            # 12{14,2{4{Hole[...]}},2{4{6}}}
             node = RuleNode(12,
                 [
                     RuleNode(14),
@@ -322,7 +322,7 @@ using Test
             io = IOBuffer()
             Base.show(io, node)
             @test String(take!(io)) ==
-                  "12{14,2{4{hole[Bool[1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]]}},2{4{6}}}"
+                  "12{14,2{4{Hole[Bool[1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]]}},2{4{6}}}"
         end
     end
 


### PR DESCRIPTION
As mentioned in #42, the display names for `Holes` are misleading/outdated. This PR updates them to match the current names of types, and also simplifies the implementation by using `Base.show_enclosed_list`.