### PR TITLE
Use `getdescendant` for `get_node_at_location`

### DIFF
--- a/src/rulenode.jl
+++ b/src/rulenode.jl
@@ -374,7 +374,7 @@ performed in both [`RuleNode`](@ref)s until nodes with a different index
 are found.
 """
 Base.isless(
-    rn₁::AbstractRuleNode, rn₂::AbstractRuleNode)::Bool = _rulenode_compare(
+rn₁::AbstractRuleNode, rn₂::AbstractRuleNode)::Bool = _rulenode_compare(
     rn₁, rn₂) == -1
 
 function _rulenode_compare(rn₁::AbstractRuleNode, rn₂::AbstractRuleNode)::Int
@@ -590,28 +590,24 @@ end
 rulesonleft(h::AbstractHole, loc::Vector{Int}) = Set{Int}(findall(h.domain))
 
 """
-	get_node_at_location(root::AbstractRuleNode, location::Vector{Int})
+	get_node_at_location(root::AbstractRuleNode, location::AbstractVector{<:Integer})
 
 Retrieves a [`RuleNode`](@ref) at the given location by reference.
 """
-function get_node_at_location(root::AbstractRuleNode, location::Vector{Int})
-    if location == []
-        return root
-    else
-        return get_node_at_location(root.children[location[1]], location[2:end])
-    end
+function get_node_at_location(root::AbstractRuleNode, location::AbstractVector{<:Integer})
+    return getdescendant(root, location)
 end
 
 """
-	get_node_at_location(root::Hole, location::Vector{Int})
+	get_node_at_location(root::Hole, location::AbstractVector{<:Integer})
 
 Retrieves the current hole, if location is this very hole. Throws error otherwise.
 """
-function get_node_at_location(root::Hole, location::Vector{Int})
-    if location == []
+function get_node_at_location(root::Hole, location::AbstractVector{<:Integer})
+    if isempty(location)
         return root
     end
-    error("Node at the specified location not found.")
+    error("Node at the specified location ($location) not found.")
 end
 
 """


### PR DESCRIPTION
Getting the node at a certain location in a tree currently allocates memory on the heap.

<details><summary>Benchmark before this PR</summary>
<p>

```julia
julia> using HerbCore, BenchmarkTools

julia> @btime get_node_at_location($(@rulenode 1{2,3{4,5}}), $([2,2]))
  50.775 ns (6 allocations: 192 bytes)
5

```

</p>
</details> 

As this is a common operation, it is likely beneficial to get rid of all allocations, if possible. `getdescendant` from `AbstractTrees` performs the same operation as `get_node_at_location`, so this change is fairly straightforward. For the `Hole` method of `get_node_at_location`, the comparison to `[]` was also allocating, and switching this to `isempty(location)` avoids the allocation and is significantly faster.

<details><summary>Benchmark after this PR</summary>
<p>

```julia
julia> using HerbCore, BenchmarkTools

julia> @btime get_node_at_location($(@rulenode 1{2,3{4,5}}), $([2,2]))
  16.826 ns (0 allocations: 0 bytes)
5

```

</p>
</details> 

I've relaxed both signatures so that location can take something other than a `Vector{Int}`. This allows for use of a `SubArray` or other `<:AbstractVector` types as a `location`.