### PR TITLE
Duplicate constraints

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "HerbCore"
 uuid = "2b23ba43-8213-43cb-b5ea-38c12b45bd45"
 authors = ["Jaap de Jong <jaapdejong15@gmail.com>", "Nicolae Filat <N.Filat@student.tudelft.nl>", "Tilman Hinnerichs <t.r.hinnerichs@tudelft.nl>", "Sebastijan Dumancic <s.dumancic@tudelft.nl>"]
-version = "0.3.11"
+version = "0.3.12"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/HerbCore.jl
+++ b/src/HerbCore.jl
@@ -36,6 +36,7 @@ export
        AbstractGrammar,
        print_tree,
        update_rule_indices!,
-       is_domain_valid
+       is_domain_valid,
+       issame
 
 end # module HerbCore

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -16,3 +16,13 @@ grammar or number of rules.
 If [`isfilled`](@ref)`(x)` and `x` has children, it checks if all children are valid.
 """
 function is_domain_valid end
+
+"""
+    issame(a, b)
+
+Returns whether the two given objects `a` and `b` (ex: [`RuleNode`](@ref),
+[`Hole`](@ref) or [`AbstractConstraint`](@ref)) are the same.
+"""
+function issame(a, b)
+    false
+end

--- a/src/rulenode.jl
+++ b/src/rulenode.jl
@@ -390,7 +390,7 @@ performed in both [`RuleNode`](@ref)s until nodes with a different index
 are found.
 """
 Base.isless(
-rn₁::AbstractRuleNode, rn₂::AbstractRuleNode)::Bool = _rulenode_compare(
+    rn₁::AbstractRuleNode, rn₂::AbstractRuleNode)::Bool = _rulenode_compare(
     rn₁, rn₂) == -1
 
 function _rulenode_compare(rn₁::AbstractRuleNode, rn₂::AbstractRuleNode)::Int

--- a/src/rulenode.jl
+++ b/src/rulenode.jl
@@ -398,7 +398,7 @@ performed in both [`RuleNode`](@ref)s until nodes with a different index
 are found.
 """
 Base.isless(
-    rn₁::AbstractRuleNode, rn₂::AbstractRuleNode)::Bool = _rulenode_compare(
+rn₁::AbstractRuleNode, rn₂::AbstractRuleNode)::Bool = _rulenode_compare(
     rn₁, rn₂) == -1
 
 function _rulenode_compare(rn₁::AbstractRuleNode, rn₂::AbstractRuleNode)::Int
@@ -769,4 +769,18 @@ function have_same_shape(node1, node2)
         end
     end
     return true
+end
+
+function issame(A::RuleNode, B::RuleNode)
+    (A.ind == B.ind) && length(A.children) == length(B.children) &&
+        all(issame(a, b) for (a, b) in zip(A.children, B.children))
+end
+
+function issame(A::Hole, B::Hole)
+    A.domain == B.domain
+end
+
+function issame(A::UniformHole, B::UniformHole)
+    A.domain == B.domain && length(A.children) == length(B.children) &&
+        all(issame(a, b) for (a, b) in zip(A.children, B.children))
 end

--- a/src/rulenode.jl
+++ b/src/rulenode.jl
@@ -90,11 +90,7 @@ function update_rule_indices!(
     end
 end
 
-"""
-    is_domain_valid(node::RuleNode, n_rules::Integer)
-
-Check whether the `node`'s rule index exceeds the number of rules `n_rules.`
-"""
+# Check whether the `node`'s rule index exceeds the number of rules `n_rules.`
 function is_domain_valid(node::RuleNode, n_rules::Integer)
     if get_rule(node) > n_rules
         return false
@@ -132,11 +128,7 @@ end
 
 UniformHole(domain) = UniformHole(domain, AbstractRuleNode[])
 
-"""
-    is_domain_valid(hole::AbstractHole, n_rules::Integer)
-
-Check if `hole`'s domain length matches `n_rules`.
-"""
+# Check if `hole`'s domain length matches `n_rules`.
 function is_domain_valid(hole::AbstractHole, n_rules::Integer)
     if length(hole.domain) != n_rules
         return false
@@ -771,16 +763,14 @@ function have_same_shape(node1, node2)
     return true
 end
 
-function issame(A::RuleNode, B::RuleNode)
-    (A.ind == B.ind) && length(A.children) == length(B.children) &&
-        all(issame(a, b) for (a, b) in zip(A.children, B.children))
+function issame(a::RuleNode, b::RuleNode)
+    (a.ind == b.ind) && length(a.children) == length(b.children) &&
+        all(issame(a, b) for (a, b) in zip(a.children, b.children))
 end
 
-function issame(A::Hole, B::Hole)
-    A.domain == B.domain
+function issame(a::UniformHole, b::UniformHole)
+    a.domain == b.domain && length(a.children) == length(b.children) &&
+        all(issame(a, b) for (a, b) in zip(a.children, b.children))
 end
 
-function issame(A::UniformHole, B::UniformHole)
-    A.domain == B.domain && length(A.children) == length(B.children) &&
-        all(issame(a, b) for (a, b) in zip(A.children, B.children))
-end
+issame(a::Hole, b::Hole) = a.domain == b.domain

--- a/test/test_rulenode.jl
+++ b/test/test_rulenode.jl
@@ -513,4 +513,58 @@
         @test is_domain_valid(hole, 9) == false
         @test is_domain_valid(hole, 4) == true
     end
+
+    @testset "issame" begin
+        # RuleNode
+        node1 = @rulenode 1{4{5, 6}, 1{2, 3}}
+        node2 = @rulenode 1{4{5, 6}, 1{2, 3}}
+        node3 = @rulenode 1{4{5, 5}, 1{2, 3}}
+        @test issame(node1, node2) == true
+        @test issame(node1, node3) == false
+        # Hole
+        hole1 = Hole([1, 1, 0, 1])
+        hole2 = Hole([1, 1, 0, 1])
+        hole3 = Hole([1, 0, 0, 1])
+        @test issame(hole1, hole2) == true
+        @test issame(hole2, hole3) == false
+
+        # UniformHole
+        hole1 = UniformHole([0, 0, 1],
+            [
+                RuleNode(14),
+                RuleNode(2, [
+                    RuleNode(4, [
+                    RuleNode(6)
+                ])
+                ])
+            ]
+        )
+        hole2 = UniformHole([0, 0, 1],
+            [
+                RuleNode(14),
+                RuleNode(2, [
+                    RuleNode(4, [
+                    RuleNode(6)
+                ])
+                ])
+            ]
+        )
+        hole3 = UniformHole([0, 0, 1],
+            [
+                RuleNode(14),
+                RuleNode(2, [
+                    RuleNode(4, [
+                    RuleNode(66)
+                ])
+                ])
+            ]
+        )
+        hole4 = UniformHole([0, 0, 1], [RuleNode(14)])
+        hole5 = UniformHole([1, 0, 1], [RuleNode(14)])
+        @test issame(hole1, hole2) == true
+        @test issame(hole1, hole3) == false
+        @test issame(hole4, hole5) == false
+
+        # TODO: test on mix
+    end
 end

--- a/test/test_rulenode.jl
+++ b/test/test_rulenode.jl
@@ -529,7 +529,7 @@
         @test issame(hole2, hole3) == false
 
         # UniformHole
-        hole1 = UniformHole([0, 0, 1],
+        uhole1 = UniformHole([0, 0, 1],
             [
                 RuleNode(14),
                 RuleNode(2, [
@@ -539,7 +539,7 @@
                 ])
             ]
         )
-        hole2 = UniformHole([0, 0, 1],
+        uhole2 = UniformHole([0, 0, 1],
             [
                 RuleNode(14),
                 RuleNode(2, [
@@ -549,7 +549,7 @@
                 ])
             ]
         )
-        hole3 = UniformHole([0, 0, 1],
+        uhole3 = UniformHole([0, 0, 1],
             [
                 RuleNode(14),
                 RuleNode(2, [
@@ -559,12 +559,13 @@
                 ])
             ]
         )
-        hole4 = UniformHole([0, 0, 1], [RuleNode(14)])
-        hole5 = UniformHole([1, 0, 1], [RuleNode(14)])
-        @test issame(hole1, hole2) == true
-        @test issame(hole1, hole3) == false
-        @test issame(hole4, hole5) == false
-
-        # TODO: test on mix
+        uhole4 = UniformHole([0, 0, 1], [RuleNode(14)])
+        uhole5 = UniformHole([1, 0, 1], [RuleNode(14)])
+        @test issame(uhole1, uhole2) == true
+        @test issame(uhole1, uhole3) == false
+        @test issame(uhole4, uhole5) == false
+        # compare different types
+        @test issame(node1, uhole2) == false
+        @test issame(hole3, uhole5) == false
     end
 end


### PR DESCRIPTION
## Changes

This PR adds the interface `issame(a, b)` that checks whether two rule nodes or holes are the same. 

## Issues

Partly addresses Herb-AI/HerbGrammar.jl#116.

Closes #56.
