### PR TITLE
Remove default `==` implementation for `AbstractHole`s

### DIFF
--- a/src/rulenode.jl
+++ b/src/rulenode.jl
@@ -340,6 +340,9 @@ function Base.:(==)(a::UniformHole, b::UniformHole)
     return a.domain == b.domain && length(a.children) == length(b.children) &&
         all(isequal(a, b) for (a, b) in zip(a.children, b.children))
 end
+function Base.:(==)(a::Hole, b::Hole)
+    return a.domain == b.domain
+end
 
 Base.copy(r::RuleNode) = RuleNode(r.ind, r._val, r.children)
 Base.copy(h::Hole) = Hole(copy(h.domain))

--- a/src/rulenode.jl
+++ b/src/rulenode.jl
@@ -340,10 +340,6 @@ function Base.:(==)(a::UniformHole, b::UniformHole)
     return a.domain == b.domain && length(a.children) == length(b.children) &&
         all(isequal(a, b) for (a, b) in zip(a.children, b.children))
 end
-function Base.:(==)(a::H, b::H) where {H <: AbstractHole}
-    return a.domain == b.domain
-end
-
 
 Base.copy(r::RuleNode) = RuleNode(r.ind, r._val, r.children)
 Base.copy(h::Hole) = Hole(copy(h.domain))


### PR DESCRIPTION
Implementers of new hole types should decide whether to follow the logic of a `Hole`, which has no children, or a `UniformHole,` which does.